### PR TITLE
try/catch parse

### DIFF
--- a/services/db.js
+++ b/services/db.js
@@ -2,8 +2,7 @@
 
 var redis = require('../redis'),
   postgres = require('../postgres/client'),
-  { CACHE_ENABLED } = require('./constants'),
-  { isUri } = require('clayutils');
+  { CACHE_ENABLED } = require('./constants');
 
 /**
  * Write a single value to cache and db

--- a/services/db.js
+++ b/services/db.js
@@ -2,7 +2,8 @@
 
 var redis = require('../redis'),
   postgres = require('../postgres/client'),
-  { CACHE_ENABLED } = require('./constants');
+  { CACHE_ENABLED } = require('./constants'),
+  { isUri } = require('clayutils');
 
 /**
  * Write a single value to cache and db
@@ -35,8 +36,16 @@ function put(key, value, testCacheEnabled) {
  */
 function get(key) {
   return redis.get(key)
-    .then(JSON.parse) // Always parse on the way out to match Mongo
-    .catch(() => postgres.get(key));
+    .then(val => {
+      try {
+        return JSON.parse(val);
+      } catch (e) {
+        return val;
+      }
+    }) // Always parse on the way out to match Postgres
+    .catch(() => {
+      return postgres.get(key);
+    });
 }
 
 /**

--- a/services/db.test.js
+++ b/services/db.test.js
@@ -23,6 +23,16 @@ describe('services/db', () => {
       });
     });
 
+    test('returns uris properly from Redis', () => {
+      redis.get.mockResolvedValue('site.com/_uris/a');
+
+      return get(KEY).then(() => {
+        expect(redis.get.mock.calls.length).toBe(1);
+        expect(redis.get).toHaveBeenCalledWith(KEY);
+        expect(postgres.get.mock.calls.length).toBe(0);
+      });
+    });
+
     test('it does call Postgres client if Redis has the data', () => {
       redis.get.mockResolvedValue(Promise.reject());
 


### PR DESCRIPTION
If a key doesn't exist in Redis the client will `catch`, but uris are stored in Redis and cannot be parsed.