### PR TITLE
Make connection pooling an environment configuration

### DIFF
--- a/postgres/client.js
+++ b/postgres/client.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_HOST, POSTGRES_PORT, POSTGRES_DB } = require('../services/constants'),
+const { POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_HOST, POSTGRES_PORT, POSTGRES_DB, CONNECTION_POOL_MIN, CONNECTION_POOL_MAX } = require('../services/constants'),
   { notFoundError } = require('../services/errors'),
   { parseOrNot, wrapInObject, decode } = require('../services/utils'),
   { findSchemaAndTable, wrapJSONStringInObject } = require('../services/utils'),
@@ -27,7 +27,8 @@ function createDBIfNotExists() {
       password: POSTGRES_PASSWORD,
       database: 'postgres',
       port: POSTGRES_PORT
-    }
+    },
+    pool: { min: CONNECTION_POOL_MIN, max: CONNECTION_POOL_MAX }
   });
 
   // https://github.com/clay/amphora-storage-postgres/pull/7/files/16d3429767943a593ad9667b0d471fefc15088d3#diff-6a1e11a6146d3a5a01f955a44a2ac07a
@@ -55,7 +56,8 @@ function connect() {
       password: POSTGRES_PASSWORD,
       database: POSTGRES_DB,
       port: POSTGRES_PORT
-    }
+    },
+    pool: { min: CONNECTION_POOL_MIN, max: CONNECTION_POOL_MAX }
   });
 
   // TODO: improve error catch! https://github.com/clay/amphora-storage-postgres/pull/7/files/16d3429767943a593ad9667b0d471fefc15088d3#diff-6a1e11a6146d3a5a01f955a44a2ac07a

--- a/services/constants.js
+++ b/services/constants.js
@@ -6,6 +6,8 @@ module.exports.POSTGRES_PASSWORD = process.env.CLAY_STORAGE_POSTGRES_PASSWORD ||
 module.exports.POSTGRES_HOST     = process.env.CLAY_STORAGE_POSTGRES_HOST;
 module.exports.POSTGRES_PORT     = process.env.CLAY_STORAGE_POSTGRES_PORT     || 5432;
 module.exports.POSTGRES_DB       = process.env.CLAY_STORAGE_POSTGRES_DB       || 'clay';
+module.exports.CONNECTION_POOL_MIN = process.env.CLAY_STORAGE_CONNECTION_POOL_MIN || 2;
+module.exports.CONNECTION_POOL_MAX = process.env.CLAY_STORAGE_CONNECTION_POOL_MAX || 10;
 
 // Redis
 module.exports.CACHE_ENABLED     = process.env.CLAY_STORAGE_POSTGRES_CACHE_ENABLED     || false;


### PR DESCRIPTION
Using the environment variables `CLAY_STORAGE_CONNECTION_POOL_MIN` and `CLAY_STORAGE_CONNECTION_POOL_MAX` we can set the connection pool.

Default values taken from https://knexjs.org/#Installation-pooling.
Closes Issue https://github.com/clay/amphora-storage-postgres/issues/19.