### PR TITLE
Enable caching get method

### DIFF
--- a/services/db.js
+++ b/services/db.js
@@ -32,15 +32,22 @@ function put(key, value, testCacheEnabled) {
  * return a Object, not stringified JSON
  *
  * @param  {String} key
+ * @param  {Boolean} testCacheEnabled used for tests
  * @return {Promise}
  */
-function get(key) {
-  return redis.get(key)
-    .then(data => {
-      if (isUri(key)) return data;
-      return JSON.parse(data); // Parse non-uri data to match Postgres
-    })
-    .catch(() => postgres.get(key));
+function get(key, testCacheEnabled) {
+  const cacheEnabled = testCacheEnabled || CACHE_ENABLED;
+
+  if (cacheEnabled) {
+    return redis.get(key)
+      .then(data => {
+        if (isUri(key)) return data;
+        return JSON.parse(data); // Parse non-uri data to match Postgres
+      })
+      .catch(() => postgres.get(key));
+  }
+
+  return postgres.get(key);
 }
 
 /**

--- a/services/db.js
+++ b/services/db.js
@@ -41,9 +41,8 @@ function get(key, testCacheEnabled) {
   if (cacheEnabled) {
     return redis.get(key)
       .then(data => {
-        if (isUri(key)) return data;
-
-        return JSON.parse(data); // Parse non-uri data to match Postgres
+        // Parse non-uri data to match Postgres
+        return isUri(key) ? data : JSON.parse(data);
       })
       .catch(() => postgres.get(key));
   }

--- a/services/db.js
+++ b/services/db.js
@@ -42,6 +42,7 @@ function get(key, testCacheEnabled) {
     return redis.get(key)
       .then(data => {
         if (isUri(key)) return data;
+
         return JSON.parse(data); // Parse non-uri data to match Postgres
       })
       .catch(() => postgres.get(key));


### PR DESCRIPTION
This PR closes: ISSUE https://github.com/clay/amphora-storage-postgres/issues/36

## Feature

- Adds a condition to call redis only if cache is enabled through a env. variable or explicitly sending a parameter.
- Adds tests to new conditions added.
