### PR TITLE
re-populates the Redis cache on GET (for published items)

### DIFF
--- a/services/db.js
+++ b/services/db.js
@@ -47,7 +47,7 @@ function get(key, testCacheEnabled) {
       .catch(() => {
         return postgres.get(key)
           .then(data => {
-            return redis.put(key, JSON.stringify(data))
+            return redis.put(key, isUri(key) ? data : JSON.stringify(data))
               .then(() => data)
               .catch(() => data);
           });

--- a/services/db.js
+++ b/services/db.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var redis = require('../redis'),
+  log = require('./log').setup({ file: __filename }),
   postgres = require('../postgres/client'),
   { isUri } = require('clayutils'),
   { CACHE_ENABLED } = require('./constants');
@@ -49,7 +50,10 @@ function get(key, testCacheEnabled) {
           .then(data => {
             return redis.put(key, isUri(key) ? data : JSON.stringify(data))
               .then(() => data)
-              .catch(() => data);
+              .catch(() => {
+                log('warn', `Failed to set Redis key ${key} after fetch from Postgres`);
+                return data;
+              });
           });
       });
   }

--- a/services/db.js
+++ b/services/db.js
@@ -48,7 +48,8 @@ function get(key, testCacheEnabled) {
         return postgres.get(key)
           .then(data => {
             return redis.put(key, JSON.stringify(data))
-              .then(() => data);
+              .then(() => data)
+              .catch(() => data);
           });
       });
   }

--- a/services/db.js
+++ b/services/db.js
@@ -44,7 +44,13 @@ function get(key, testCacheEnabled) {
         // Parse non-uri data to match Postgres
         return isUri(key) ? data : JSON.parse(data);
       })
-      .catch(() => postgres.get(key));
+      .catch(() => {
+        return postgres.get(key)
+          .then(data => {
+            return redis.put(key, JSON.stringify(data))
+              .then(() => data);
+          });
+      });
   }
 
   return postgres.get(key);

--- a/services/db.test.js
+++ b/services/db.test.js
@@ -55,6 +55,21 @@ describe('services/db', () => {
       });
     });
 
+    test('it does not encode uri string as json in Redis on GET', () => {
+      const uri = 'foo.com/_uris/bar',
+        page = 'foo.com/_pages/bar';
+
+      redis.get.mockResolvedValue(Promise.reject());
+      postgres.get.mockResolvedValue(Promise.resolve(page));
+      redis.put.mockResolvedValue(Promise.resolve());
+
+      return get(uri, true).then(() => {
+        expect(redis.get.mock.calls.length).toBe(1);
+        expect(redis.put).toHaveBeenCalledWith(uri, page);
+      });
+    });
+
+
     test('it calls Postgres client if Redis does not have the data, saves result to Redis', () => {
       redis.get.mockResolvedValue(Promise.reject());
       postgres.get.mockResolvedValue(Promise.resolve(VALUE));

--- a/services/db.test.js
+++ b/services/db.test.js
@@ -68,6 +68,20 @@ describe('services/db', () => {
         expect(redis.put).toHaveBeenCalledWith(KEY, JSON.stringify(VALUE));
       });
     });
+
+    test('it calls Postgres client if Redis does not have the data, still returns on PUT error', () => {
+      redis.get.mockResolvedValue(Promise.reject());
+      postgres.get.mockResolvedValue(Promise.resolve(VALUE));
+      redis.put.mockResolvedValue(Promise.reject());
+
+      return get(KEY, true).then(() => {
+        expect(redis.get.mock.calls.length).toBe(1);
+        expect(postgres.get.mock.calls.length).toBe(1);
+        expect(redis.get).toHaveBeenCalledWith(KEY);
+        expect(postgres.get).toHaveBeenCalledWith(KEY);
+        expect(redis.put).toHaveBeenCalledWith(KEY, JSON.stringify(VALUE));
+      });
+    });
   });
 
   describe('put', () => {

--- a/services/db.test.js
+++ b/services/db.test.js
@@ -55,14 +55,17 @@ describe('services/db', () => {
       });
     });
 
-    test('it does call Postgres client if Redis has the data', () => {
+    test('it calls Postgres client if Redis does not have the data, saves result to Redis', () => {
       redis.get.mockResolvedValue(Promise.reject());
+      postgres.get.mockResolvedValue(Promise.resolve(VALUE));
+      redis.put.mockResolvedValue(Promise.resolve());
 
       return get(KEY, true).then(() => {
         expect(redis.get.mock.calls.length).toBe(1);
         expect(postgres.get.mock.calls.length).toBe(1);
         expect(redis.get).toHaveBeenCalledWith(KEY);
         expect(postgres.get).toHaveBeenCalledWith(KEY);
+        expect(redis.put).toHaveBeenCalledWith(KEY, JSON.stringify(VALUE));
       });
     });
   });


### PR DESCRIPTION
This commit introduces a mechanism to re-populate the cache when we
encounter GET scenarios where data is **present** in Postgres, but
**absent** in Redis.

Merging this change will mean the cache is no longer stateful,
a data loss will result in a re-population of the cache without intervention.

Prior to this commit, the Redis cache was only acting as a cache for
components modified **after** the cache's inception. As a result, it was
important to have a disaster recovery plan in the case of a cache loss.