### PR TITLE
uses global Redis keyspace rather than a hashmap

### DIFF
--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -8,7 +8,6 @@ To define where Postgres and Redis clients will connect to you can define the fo
 - [`CLAY_STORAGE_POSTGRES_PORT`](#clay_storage_postgres_port)
 - [`CLAY_STORAGE_POSTGRES_DB`](#clay_storage_postgres_db)
 - [`CLAY_STORAGE_POSTGRES_CACHE_ENABLED`](#clay_storage_postgres_cache_enabled)
-- [`CLAY_STORAGE_POSTGRES_CACHE_HASH`](#clay_storage_postgres_cache_hash)
 - [`CLAY_STORAGE_POSTGRES_CACHE_HOST`](#clay_storage_postgres_cache_host)
 
 ---
@@ -55,12 +54,6 @@ The following values pertain to the configuration of the Redis cashing layer wit
 **Default:** `false` _(Boolean)_
 
 If set to `true` the module will leverage Redis as a cache for published data, uris, and user data to enable faster rendering of reader facing pages.
-
-### `CLAY_STORAGE_POSTGRES_CACHE_HASH`
-
-**Default:** `clay` _(String)_
-
-The hash within Redis that values will be stored in.
 
 ### `CLAY_STORAGE_POSTGRES_CACHE_HOST`
 

--- a/redis/index.js
+++ b/redis/index.js
@@ -2,7 +2,7 @@
 
 const bluebird = require('bluebird'),
   Redis = require('ioredis'),
-  { REDIS_URL, REDIS_HASH } = require('../services/constants'),
+  { REDIS_URL } = require('../services/constants'),
   { isPublished, isUri, isUser } = require('clayutils'),
   { notFoundError, logGenericError } = require('../services/errors');
 var log = require('../services/log').setup({ file: __filename });
@@ -50,7 +50,7 @@ function shouldProcess(key) {
 function put(key, value) {
   if (!shouldProcess(key)) return bluebird.resolve();
 
-  return module.exports.client.hsetAsync(REDIS_HASH, key, value);
+  return module.exports.client.setAsync(key, value);
 }
 
 /**
@@ -64,7 +64,7 @@ function get(key) {
     return bluebird.reject(notFoundError(key));
   }
 
-  return module.exports.client.hgetAsync(REDIS_HASH, key)
+  return module.exports.client.getAsync(key)
     .then(data => data || bluebird.reject(notFoundError(key)));
 }
 
@@ -93,7 +93,7 @@ function batch(ops) {
     return bluebird.resolve();
   }
 
-  return module.exports.client.hmsetAsync(REDIS_HASH, batch);
+  return module.exports.client.msetAsync(batch);
 }
 
 /**
@@ -104,7 +104,7 @@ function batch(ops) {
 function del(key) {
   if (!shouldProcess(key) || !module.exports.client) return bluebird.resolve();
 
-  return module.exports.client.hdelAsync(REDIS_HASH, key);
+  return module.exports.client.delAsync(key);
 }
 
 module.exports.client = null;

--- a/redis/index.test.js
+++ b/redis/index.test.js
@@ -19,10 +19,10 @@ var { createClient, get, put, batch, del, stubClient } = require('./index'),
   ],
   CLIENT = {
     on: jest.fn(),
-    hmsetAsync: jest.fn(),
-    hsetAsync: jest.fn(),
-    hdelAsync: jest.fn(),
-    hgetAsync: jest.fn()
+    msetAsync: jest.fn(),
+    setAsync: jest.fn(),
+    delAsync: jest.fn(),
+    getAsync: jest.fn()
   };
 
 beforeEach(() => {
@@ -41,9 +41,9 @@ describe('redis', () => {
   ])
   ('put', (val, key, data, resolution) => {
     test(`does ${resolution ? '' : 'not '}put ${val} to Redis`, () => {
-      CLIENT.hsetAsync.mockResolvedValue('');
+      CLIENT.setAsync.mockResolvedValue('');
       return put(key, data)
-        .then(() => expect(CLIENT.hsetAsync.mock.calls.length).toBe(resolution));
+        .then(() => expect(CLIENT.setAsync.mock.calls.length).toBe(resolution));
     });
   });
 
@@ -58,9 +58,9 @@ describe('redis', () => {
   ])
   ('del', (val, key, resolution) => {
     test(`does ${resolution ? '' : 'not '}del ${val} from Redis`, () => {
-      CLIENT.hdelAsync.mockResolvedValue('');
+      CLIENT.delAsync.mockResolvedValue('');
       return del(key)
-        .then(() => expect(CLIENT.hdelAsync.mock.calls.length).toBe(resolution));
+        .then(() => expect(CLIENT.delAsync.mock.calls.length).toBe(resolution));
     });
   });
 
@@ -75,18 +75,18 @@ describe('redis', () => {
     });
 
     test('retrieves data from Redis', () => {
-      CLIENT.hgetAsync.mockResolvedValue(JSON.stringify(FAKE_DATA));
+      CLIENT.getAsync.mockResolvedValue(JSON.stringify(FAKE_DATA));
       return get('somekey')
         .then(() => {
-          expect(CLIENT.hgetAsync.mock.calls.length).toBe(1);
+          expect(CLIENT.getAsync.mock.calls.length).toBe(1);
         });
     });
 
     test('rejects with a NotFoundError if the key does not exist', () => {
-      CLIENT.hgetAsync.mockResolvedValue(undefined);
+      CLIENT.getAsync.mockResolvedValue(undefined);
       return get('somekey')
         .catch((err) => {
-          expect(CLIENT.hgetAsync.mock.calls.length).toBe(1);
+          expect(CLIENT.getAsync.mock.calls.length).toBe(1);
           expect(err.name).toEqual('NotFoundError');
         });
     });
@@ -94,32 +94,32 @@ describe('redis', () => {
 
   describe('batch', () => {
     test('processes a batch of operations and writes them', () => {
-      CLIENT.hmsetAsync.mockResolvedValue('');
+      CLIENT.msetAsync.mockResolvedValue('');
 
       return batch(FAKE_OPS)
         .then(() => {
-          expect(CLIENT.hmsetAsync.mock.calls.length).toBe(1);
+          expect(CLIENT.msetAsync.mock.calls.length).toBe(1);
         });
     });
 
     test('resolves quickly if the ops length is zero', () => {
-      CLIENT.hmsetAsync.mockResolvedValue('');
+      CLIENT.msetAsync.mockResolvedValue('');
 
       return batch([])
         .then(() => {
-          expect(CLIENT.hmsetAsync.mock.calls.length).toBe(0);
+          expect(CLIENT.msetAsync.mock.calls.length).toBe(0);
         });
     });
 
     test('resolves if no ops pass the filter', () => {
-      CLIENT.hmsetAsync.mockResolvedValue('');
+      CLIENT.msetAsync.mockResolvedValue('');
 
       return batch([{
         key: 'foo.com/_components/bar',
         value: '{"foo": true}'
       }])
         .then(() => {
-          expect(CLIENT.hmsetAsync.mock.calls.length).toBe(0);
+          expect(CLIENT.msetAsync.mock.calls.length).toBe(0);
         });
     });
   });

--- a/services/constants.js
+++ b/services/constants.js
@@ -13,7 +13,6 @@ module.exports.CONNECTION_POOL_MAX = parseInt(process.env.CLAY_STORAGE_CONNECTIO
 
 // Redis
 module.exports.CACHE_ENABLED     = process.env.CLAY_STORAGE_POSTGRES_CACHE_ENABLED     || false;
-module.exports.REDIS_HASH        = process.env.CLAY_STORAGE_POSTGRES_CACHE_HASH        || 'clay';
 module.exports.REDIS_URL         = process.env.CLAY_STORAGE_POSTGRES_CACHE_HOST;
 
 // Application code


### PR DESCRIPTION
Utilizing a hashmap can be an effective strategy for reducing the
memory footprint of objects in long-term storage.

However... it's only efficient when the number of items is less than
the value of `hash-max-ziplist-entries`, which is 512 by default.

In NYMag's case, one hash map was storing 13MM+ items.

This configuration failed to take advantage of the memory benefits of
HMAP and completely eliminated the posibility of setting a TTL on keys or enabling Redis's LRU functionality (both useful for a cache).

This commit will utilize the global keyspace for cached items.
The change mostly boils down to removing the `h` in front of most commands.