### PR TITLE
enables expiration in Redis cache via CLAY_STORAGE_POSTGRES_CACHE_TTL

### DIFF
--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -60,3 +60,9 @@ If set to `true` the module will leverage Redis as a cache for published data, u
 **Default:** `redis://localhost:6379` _(String)_
 
 The Redis host to connect to. Should be [Redis Protocol](https://redis.io/topics/protocol) and include the port.
+
+### `CLAY_STORAGE_POSTGRES_CACHE_TTL`
+
+**Default:** `86400` _(Number)_
+
+This determines how long items will remain in the query cache (in seconds). The default is 24 hours.

--- a/services/constants.js
+++ b/services/constants.js
@@ -14,6 +14,9 @@ module.exports.CONNECTION_POOL_MAX = parseInt(process.env.CLAY_STORAGE_CONNECTIO
 // Redis
 module.exports.CACHE_ENABLED     = process.env.CLAY_STORAGE_POSTGRES_CACHE_ENABLED     || false;
 module.exports.REDIS_URL         = process.env.CLAY_STORAGE_POSTGRES_CACHE_HOST;
+module.exports.REDIS_TTL = process.env.CLAY_STORAGE_POSTGRES_CACHE_TTL
+  ? Number(process.env.CLAY_STORAGE_POSTGRES_CACHE_TTL)
+  : 60 * 60 * 24;  // One day.
 
 // Application code
 module.exports.DATA_STRUCTURES   = ['components', 'layouts', 'pages', 'uris', 'lists', 'users'];

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -48,6 +48,7 @@ describe('integration tests', () => {
     // the implementation of each of the specific classes via conditionals.
     if (testcase.cache && testcase.published) {
       await expect(redis.get(key)).resolves.toEqual(JSON.stringify(val));
+      await expect(redis.client.ttl(key)).resolves.toBeGreaterThan(-1);
     } else {
       await expect(redis.get(key)).rejects.toThrow();
     }
@@ -85,6 +86,7 @@ describe('integration tests', () => {
       await expect(db.get(key, testcase.cache)).resolves.toEqual(val);
       if (testcase.cache && (testcase.published || expectStr)) {
         await expect(redis.get(key)).resolves.toEqual(expectStr ? val : JSON.stringify(val));
+        await expect(redis.client.ttl(key)).resolves.toBeGreaterThan(-1);
       } else {
         await expect(redis.get(key)).rejects.toThrow();
       }


### PR DESCRIPTION
This commit enables a global TTL for cached components by setting the
`CLAY_STORAGE_POSTGRES_CACHE_TTL` environment variable.

Setting a TTL will help reduce the persistent cache size and massive
storage requirements of keeping the entire database in memory.

A TTL will also guarantee eventual consistency with the underlying
persistence layer (Postgres), even if things are modified out-of-band.

The implementation here utilizes Redis pipelines to eliminate the
overhead of the TCP handshake for each command sent. We have to do this
for efficiency because there is not `MSETEX` method in Redis (to set
multiple keys with TTLs at once).

One downside to the pipeline approach is that it may not be
well-supported when running Redis in Cluster mode, which could be a
valid use case for very large or elastic Amphora distributions.

~The changes to `redis/index.test.js` are not exactly providing the
assurance we would want about how this all works. I think it
underscores a need for a new testing paradigm in this library (that
includes a `postgres` and `redis` running in Docker). There are so many
mocks present that we are often just testing whether the code we wrote is
calling the functions we wrote them to call.~

_Edit: Integration tests have been added._

~:warning: This PR depends on #58 being merged. :warning:~ (merged)