### PR TITLE
Instances list endpoint pagination

### DIFF
--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -9,6 +9,7 @@ To define where Postgres and Redis clients will connect to you can define the fo
 - [`CLAY_STORAGE_POSTGRES_DB`](#clay_storage_postgres_db)
 - [`CLAY_STORAGE_POSTGRES_CACHE_ENABLED`](#clay_storage_postgres_cache_enabled)
 - [`CLAY_STORAGE_POSTGRES_CACHE_HOST`](#clay_storage_postgres_cache_host)
+- [`CLAY_STORAGE_POSTGRES_PAGE_SIZE`](#clay_storage_postgres_page_size)
 
 ---
 ## Postgres
@@ -42,6 +43,12 @@ The port where your Postgres instance resides on its host.
 **Default:** `clay` _(String)_
 
 The database within Postgres to connect to.
+
+### `CLAY_STORAGE_PAGE_SIZE`
+
+**Default:** `null` _(Number)_
+
+Default page size for list queries. Enables pagination by default on list endpoints.  
 
 ---
 

--- a/index.js
+++ b/index.js
@@ -12,3 +12,4 @@ module.exports.patchMeta = db.patchMeta;
 module.exports.getMeta = db.getMeta;
 module.exports.raw = db.raw;
 module.exports.createReadStream = db.createReadStream;
+module.exports.paginate = db.paginate;

--- a/services/constants.js
+++ b/services/constants.js
@@ -11,6 +11,8 @@ module.exports.POSTGRES_DB       = process.env.CLAY_STORAGE_POSTGRES_DB       ||
 module.exports.CONNECTION_POOL_MIN = parseInt(process.env.CLAY_STORAGE_CONNECTION_POOL_MIN, 10) || 2;
 module.exports.CONNECTION_POOL_MAX = parseInt(process.env.CLAY_STORAGE_CONNECTION_POOL_MAX, 10) || 10;
 
+module.exports.PAGE_SIZE = parseInt(process.env.CLAY_STORAGE_PAGE_SIZE) || null;
+
 // Redis
 module.exports.CACHE_ENABLED     = process.env.CLAY_STORAGE_POSTGRES_CACHE_ENABLED     || false;
 module.exports.REDIS_URL         = process.env.CLAY_STORAGE_POSTGRES_CACHE_HOST;

--- a/services/db.js
+++ b/services/db.js
@@ -101,3 +101,4 @@ module.exports.putMeta = postgres.putMeta;
 module.exports.getMeta = postgres.getMeta;
 module.exports.patchMeta = postgres.patchMeta;
 module.exports.createReadStream = postgres.createReadStream;
+module.exports.paginate = postgres.paginate;


### PR DESCRIPTION
- Adds `paginate()` to postgres query functions. 
- Adds `PAGE_SIZE` env var, that when defined, sets up pagination by default
- No functional change if `PAGE_SIZE` is not defined

Pagination will work by fetching the first page, then doing another request with the last item that was returned `prev=<uri>`. Paginating in this way using the "seek" method isn't obviously better than using `offset` at first glance, especially considering that it requires an `order by` clause, but in local testing it is significantly faster especially at high offsets. 

Here are the results from querying a table of `clay-paragraph` components with a page size of 10:

### 0th item
- no difference
### 10,000
- offset: 9 ms
- seek: 5 ms
### 100,000
- offset: 3189 ms
- seek: 5 ms
### 500,000
- offset: 17375 ms
- seek: 9 ms
### No paginating, get all instances
- 8285 ms

This approach closes a current DoS vector and also avoids creating an even worse vector. 