### PR TITLE
enables package publishing via CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,33 @@
 ---
 version: 2
 
-templates:
-  cache: &cache
-    key: v1-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
+references:
+  filter_all: &filter_all
+    filters:
+      branches:
+        only: /.*/
+      tags:
+        only: /.*/
+
+  filter_head: &filter_head
+    filters:
+      branches:
+        only: master
+      tags:
+        only: stg
+
+  filter_release: &filter_release
+    filters:
+      branches:
+        ignore: /.*/
+      tags:
+        only: /v[0-9]+\.[0-9]+\.[0-9]+(-[0-9])?/
 
 jobs:
   test:
     working_directory: ~/repo
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:12
       - image: redis
       - image: postgres
         environment:
@@ -18,42 +36,43 @@ jobs:
       - checkout
       - setup_remote_docker
       - restore_cache:
-          <<: *cache
+          key: v2-node12-dependencies-{{ checksum "package.json" }}
       - run: npm install
-      - run: npm test
-      - run: npm run integration-ci
       - save_cache:
-          <<: *cache
+          key: v2-node12-dependencies-{{ checksum "package.json" }}
           paths:
             - node_modules
-      - persist_to_workspace:
-          root: ~/repo
-          paths: .
+      - run: npm test
+      - run: npm run integration-ci
+      - run: |
+          if [[ "$CIRCLE_BRANCH" == "master" ]]; then
+            cat coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
+          fi
 
-  deploy:
-    working_directory: ~/repo
+  deploy_package:
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:12
+    working_directory: ~/repo
     steps:
-      - attach_workspace:
-          at: ~/repo
-      - run:
-          name: Send to Coveralls
-          command: cat coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
+      - checkout
+      - run: |
+          echo "$NPMRC" > ~/.npmrc
+          chmod 600 ~/.npmrc
+          if [[ "$CIRCLE_TAG" = *-* ]]; then
+            npm publish --tag=prerelease
+          else
+            npm publish
+          fi
 
 workflows:
   version: 2
   test-deploy:
     jobs:
       - test:
-          filters:
-            tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+/
-      - deploy:
+          <<: *filter_all
+      - deploy_package:
+          <<: *filter_release
+          context:
+            - npm-publish
           requires:
             - test
-          filters:
-            tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+/
-            branches:
-              ignore: /.*/

--- a/.circleci/scripts/release.sh
+++ b/.circleci/scripts/release.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# This script will increment the package version in package.json.
+# It will then tag the HEAD of the master branch with the version number
+# and push the tag to the origin (GitHub)
+
+
+set -e
+
+OPTIONS="(prepatch|patch|preminor|minor|premajor|major)"
+USAGE="usage: npm release $OPTIONS"
+SEMVAR="$1"
+
+# Releases should only be cut from the master branch.
+# They can be manually cut from other branches, but that should be a very
+# intentional process.
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if [[ "$BRANCH" != "master" ]]; then
+    >&2 echo "ERROR: Not on the master branch, will not release."
+    exit 1
+fi
+
+case $SEMVAR in
+    minor)
+        ;;
+    major)
+        ;;
+    patch)
+        ;;
+    premajor)
+        ;;
+    preminor)
+        ;;
+    prepatch)
+        ;;
+    *)
+        SEMVAR=prepatch
+        >&2 echo "WARNING: No $OPTIONS provided, defaulting to PREPATCH."
+        >&2 echo "$USAGE"
+        ;;
+esac
+
+git pull --rebase origin master
+version="$(npm version $SEMVAR)"
+git push origin master
+git push origin "tags/$version"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "integration": "./tests/integration.sh",
     "integration-ci": "npx jest --forceExit --runInBand tests/integration.test.js",
     "jest": "jest --testPathIgnorePatterns tests/*",
-    "test": "npm run eslint && npm run jest"
+    "test": "npm run eslint && npm run jest",
+    "release": "./.circleci/scripts/release.sh"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The typical workflow will involve creating a release from the **base** branch (currently: `master`).

1. Start by creating a prerelease candidate, selecting the correct version to increment.
```sh
npm run release (prepatch|preminor|premajor)
```

2. This will run `npm version (selection)` and push the branch/tag.

3. CircleCI will publish a package with `--tag=prerelease`, eg. `v8.17.1-0`.

4. When we are ready to promote a release from `prerelease` to `latest` run the following.
```sh
npm run release (patch|minor|major)
```

5. This will run `npm version (selection)` and push the branch/tag.

6. CircleCI will publish a package, eg `v8.17.1`.