### PR TITLE
adds postgres constraint to prevent circular URIs

### DIFF
--- a/services/migrations/005_prevent_circular_uris.sql
+++ b/services/migrations/005_prevent_circular_uris.sql
@@ -1,0 +1,1 @@
+ALTER TABLE uris ADD CONSTRAINT id_ne_data CHECK (id <> data);


### PR DESCRIPTION
This commit addresses an edge case where Amphora may allow a URI like this to be created:

```
-[ RECORD 1 ]------------------------------------------------------
id   | example.com/_uris/ZXhhbXBsZS5jb20vZXhhbXBsZQ==
data | example.com/_uris/ZXhhbXBsZS5jb20vZXhhbXBsZQ==
url  | example.com/example
```

Visiting `https://example.com/example` would result in an infinite redirect.